### PR TITLE
Add machinecell example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ library | classification | example app
 [euphoria](https://hackage.haskell.org/package/euphoria) | scenario 0, higher-order, step signals, behaviours and events | [code](euphoria-example/Main.hs)
 [FRPNow](https://hackage.haskell.org/package/frpnow) | scenario 0, higher-order, behaviours and events | [code](frpnow-example/Main.hs)
 [grapefruit](https://hackage.haskell.org/package/grapefruit-frp) | scenario 0, higher-order, step signals, behaviours and events | [code](grapefruit-example/Main.hs)
+[machinecell](https://hackage.haskell.org/package/machinecell) | scenarios 0 and 5, arrowized, signals | [code](machinecell-example/Main.hs)
 [netwire](https://hackage.haskell.org/package/netwire) | all three scenarios, arrowized, continuous, signals | [code](netwire-example/Main.hs)
 [varying](https://hackage.haskell.org/package/varying) | all three scenarios, arrowized or applicative, continuous, signals | [code](varying-example/Main.hs)
 [ordrea](https://hackage.haskell.org/package/ordrea) | scenario 0, higher-order, step signals, behaviours and events | [code](ordrea-example/Main.hs)

--- a/machinecell-example/GlossInterface.hs
+++ b/machinecell-example/GlossInterface.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE Arrows #-}
+module GlossInterface where
+
+import Prelude hiding (id, (.))
+import Control.Category
+import Control.Arrow
+import Data.Functor ((<$))
+
+import qualified Control.Arrow.Machine as P
+import Graphics.Gloss
+import qualified Graphics.Gloss.Interface.IO.Game as G
+
+type MainInput = Either Float G.Event
+type MainState = P.ProcessA (Kleisli IO) (P.Event MainInput) (P.Event Picture)
+
+
+feedEvent ::
+    MainInput ->
+    (MainState, Picture) ->
+    IO (MainState, Picture)
+feedEvent x (pa, pic) =
+  do
+    (P.ExecInfo {P.yields = l}, pa') <-
+        runKleisli (P.stepRun pa) x
+    return (pa', if null l then pic else last l)
+
+
+playMachinecell ::
+    Display ->
+    Color ->
+    Int ->
+    P.ProcessA (Kleisli IO) (Float, P.Event G.Event) Picture ->
+    IO ()
+playMachinecell disp c freq network =
+    G.playIO
+        disp
+        c
+        freq
+        (network', Blank)
+        (return . snd)
+        (feedEvent . Right)
+        (feedEvent . Left)
+  where
+    network' = proc e ->
+      do
+        t <- P.accum 0.0 -< (+) <$> P.filterLeft e
+        pic <- network -< (t, P.filterRight e)
+        returnA -< pic <$ e

--- a/machinecell-example/Main.hs
+++ b/machinecell-example/Main.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE Arrows #-}
+
+module
+    Main
+where
+
+import Prelude hiding (id, (.))
+import Control.Category
+import Control.Arrow
+import Control.Monad
+import Data.Functor ((<$))
+
+import qualified Control.Arrow.Machine as P
+import Graphics.Gloss
+import qualified Graphics.Gloss.Interface.IO.Game as G
+
+import Buttons
+import GlossInterface
+
+
+mainArrow :: P.ProcessA (Kleisli IO) (Float, P.Event G.Event) Picture
+mainArrow = proc (_, e) ->
+  do
+    let
+        click0 = P.filterEvent (Just Click ==) $ filter0 <$> e
+        click5 = P.filterEvent (Just Click ==) $ filter5 <$> e
+        click10 = P.filterEvent (Just Click ==) $ filter10 <$> e
+
+        toggle0 = P.filterEvent (Just Toggle ==) $ filter0 <$> e
+        toggle5 = P.filterEvent (Just Toggle ==) $ filter5 <$> e
+        toggle10 = P.filterEvent (Just Toggle ==) $ filter10 <$> e
+
+    mode0 <- P.accum True -< not <$ toggle0
+    mode5 <- P.accum True -< not <$ toggle5
+    mode10 <- P.accum True -< not <$ toggle10
+
+
+    -- ---------------------------
+    -- First order implementation
+    -- ---------------------------
+
+    count0 <- P.accum 0 <<< P.gather -< [(+1) <$ click0, const 0 <$ toggle0]
+    count5 <- P.accum 0 -< (if mode5 then (+1) else id) <$ click5
+    count10 <- P.accum 0 -< (+1) <$ click10
+
+    let
+        show0 = if mode0 then count0 else -1
+        show5 = if mode5 then count5 else -1
+        show10 = if mode10 then count10 else -1
+
+
+    -- ---------------------------
+    -- Higher order implementation
+    -- ---------------------------
+
+    -- Every toggle event causes switch of counters, with every counter is newly created.
+    show0D <-
+        (let
+            active _ =
+                P.switch (counter *** dropE 1) inactive
+            inactive _ =
+                P.switch (pure (-1) *** dropE 1) active
+          in
+            P.switch (counter *** id) inactive)
+                -< (click0, () <$ toggle0)
+
+    -- Every toggle event causes switch of a counter, with one counter reused.
+    show5D <-
+        (let
+            test = proc ((_, toggle), _) ->
+                returnA -< toggle
+
+            active pa _ =
+                P.kSwitch pa (test >>> dropE 1) inactive
+            inactive pa _ =
+                P.switch (pure (-1) *** dropE 1) (active pa)
+          in
+            P.kSwitch (arr fst >>> counter) test inactive)
+                -< (click5, () <$ toggle5)
+
+    returnA -<
+        renderButtons show0 (Just show0D) show5 (Just show5D) show10 Nothing
+
+  where
+    counter = proc e ->
+        P.accum 0 -< (+1) <$ e
+
+    dropE n = P.construct $
+      do
+        replicateM_ n P.await
+        forever (P.await >>= P.yield)
+
+
+main :: IO ()
+main =
+    playMachinecell
+        (InWindow "Machinecell Example" (320, 240) (800, 200))
+        white
+        300
+        mainArrow
+

--- a/machinecell-example/Setup.hs
+++ b/machinecell-example/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/machinecell-example/machinecell-example.cabal
+++ b/machinecell-example/machinecell-example.cabal
@@ -1,0 +1,18 @@
+name:                machinecell-example
+version:             0.1.0.0
+license:             PublicDomain
+author:              Hidenori Azuma
+maintainer:          as.capabl@gmail.com
+category:            FRP
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable machinecell-example
+  hs-source-dirs:      ., ../shared
+  main-is:             Main.hs
+  build-depends:       base >=4.6 && <4.9
+                     , gloss >=1.7.8.1
+                     , machinecell >= 3.0.1
+                     , gloss-algorithms
+  default-language:    Haskell2010
+  ghc-options: -W -Wall


### PR DESCRIPTION
Machinecell is an arrowized stream processing library.
The concept is similar to auto's. Actually machinecell is more close to ordinal pipe-like libraries such as conduit, pipes, or machines. But it can still express Yampa-like Arrowized FRP semantics (see the example of this pull request).