### PR TITLE
Reactive-banana is continuous

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ library | classification | example app
 [varying](https://hackage.haskell.org/package/varying) | all three scenarios, arrowized or applicative, continuous, signals | [code](varying-example/Main.hs)
 [ordrea](https://hackage.haskell.org/package/ordrea) | scenario 0, higher-order, step signals, behaviours and events | [code](ordrea-example/Main.hs)
 [reactive-bacon](https://hackage.haskell.org/package/reactive-bacon) | scenarios 0 and 5, asynchronous data flow, behaviours and events | [code](reactive-bacon-example/Main.hs)
-[reactive-banana](https://hackage.haskell.org/package/reactive-banana) | scenario 0, higher-order, behaviours and events | [code](reactive-banana-example/Main.hs)
+[reactive-banana](https://hackage.haskell.org/package/reactive-banana) | scenario 0, higher-order, continuous, behaviours and events | [code](reactive-banana-example/Main.hs)
 [reflex](https://hackage.haskell.org/package/reflex) | scenarios 0 and 5, higher-order, behaviours and events | [code](reflex-example/Main.hs)
 [Yampa](https://hackage.haskell.org/package/Yampa) | scenarios 0 and 5, arrowized, continuous, signals | [code](Yampa-example/Main.hs)
 [sodium](https://hackage.haskell.org/package/sodium) | scenarios 0 and 5, higher-order, behaviours and events | [deprecated](http://apfelmus.nfshost.com/blog/2015/10/29-frp-banana-1-0.html)


### PR DESCRIPTION
Source:
https://apfelmus.nfshost.com/blog/2015/10/29-frp-banana-1-0.html
"... reactive-banana is a mature library for functional reactive programming (FRP) that supports first-class Events and Behaviors, continuous time ..."